### PR TITLE
pin viscy due to breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pytorch-metric-learning",
     "cp-measure",
     "iohub>=0.3.0a7",
-    "viscy",
+    "viscy<=0.4.1",
     "monai",
     "diffusers[torch]",
     "phate>=1.0.7",


### PR DESCRIPTION
Pinning `ops-model` repo to viscy `<=0.4.1` as `0.5.0` brings breaking changes.
The `ops-process` repo hard pins to 0.3.0 so nothing to worry about if one uses the monorepo directly 