### PR TITLE
Data loaders: prefer nuclei_seg, fall back to nuclear_seg

### DIFF
--- a/src/ops_model/data/data_loader.py
+++ b/src/ops_model/data/data_loader.py
@@ -463,7 +463,14 @@ class CellProfileDataset(BaseDataset):
         fov = self.stores[ci.store_key][well]["0"]
         mask_label = getattr(ci, "mask_label", "cell_seg")
         cell_mask_fov = self.stores[ci.store_key][well]["labels"][mask_label]["0"]
-        nuc_mask_fov = self.stores[ci.store_key][well]["labels"]["nuclear_seg"]["0"]
+        # Nuclear mask: prefer native-20x `nuclei_seg` (from the
+        # `submit_nuclei_segmentation_jobs` step), fall back to legacy
+        # `nuclear_seg` (5x-upscaled, from `segment_and_stitch_pheno`).
+        # Both labels are 20x-shaped at level 0 so bbox slicing is unchanged.
+        # See ops_process PR #113.
+        _labels_group = self.stores[ci.store_key][well]["labels"]
+        _nuc_label = "nuclei_seg" if "nuclei_seg" in _labels_group else "nuclear_seg"
+        nuc_mask_fov = _labels_group[_nuc_label]["0"]
         bbox = ast.literal_eval(ci.bbox)
         gene_label = self.label_int_lut[ci.gene_name]
         total_index = ci.total_index

--- a/src/ops_model/features/cp_extraction.py
+++ b/src/ops_model/features/cp_extraction.py
@@ -1016,7 +1016,14 @@ def extract_cp_features_bulk_read(
     img_arr = stores[store_key][well]["0"]
     mask_label = getattr(first_row, "mask_label", "cell_seg")
     cell_seg_arr = stores[store_key][well]["labels"][mask_label]["0"]
-    nuc_seg_arr = stores[store_key][well]["labels"]["nuclear_seg"]["0"]
+    # Nuclear mask: prefer native-20x `nuclei_seg` (from the
+    # `submit_nuclei_segmentation_jobs` step), fall back to legacy
+    # `nuclear_seg` (5x-upscaled, from `segment_and_stitch_pheno`).
+    # Both labels are 20x-shaped at level 0; bbox slicing unchanged.
+    # See ops_process PR #113.
+    _labels_group = stores[store_key][well]["labels"]
+    _nuc_label = "nuclei_seg" if "nuclei_seg" in _labels_group else "nuclear_seg"
+    nuc_seg_arr = _labels_group[_nuc_label]["0"]
     chunk_size = img_arr.chunks[-1]  # 512
 
     # Phase 1: Identify unique chunks from bounding boxes


### PR DESCRIPTION
## Summary

Updates the two cell-extraction data paths to try the new native-20x `nuclei_seg` label first (produced by `submit_nuclei_segmentation_jobs` in [ops_process PR #113](https://github.com/royerlab/ops_process/pull/113)), with fall-through to the legacy 5x-upscaled `nuclear_seg` from `segment_and_stitch_pheno`.

Files touched (each is a 9-line addition, identical pattern):
- `src/ops_model/data/data_loader.py:466` — `CellProfileDataset.__getitem__`
- `src/ops_model/features/cp_extraction.py:1019` — bulk CP feature read

Both labels are **20x-shaped at level 0** in phenotyping_v3.zarr (the legacy step segmented at 5x and then 4× nearest-neighbor upscaled to 20x for storage), so **bbox slicing is unchanged**. The existing `min_h = min(...)` clip block at `data_loader.py:498` handles the residual ~3 px shape diff between native-20x and 5x-upscaled-to-20x masks.

## Test plan / measured impact

Per-cell A/B comparison over 500 sampled cells from `A1_linked_pheno_iss_cp.csv` (ops0094_20251217):

| metric | legacy mean | new mean | Δ |
|---|---|---|---|
| nuc area (px) | 2179.6 | 2140.4 | **−1.80%** |
| nuc/cell ratio | 0.200 | 0.197 | **−1.78%** |

Per-cell nuclear-mask IoU (NEW vs LEGACY, within the cell mask):
- mean: 0.845, median: 0.856
- IoU < 0.5: 0.8% of cells (large disagreement — over/under-seg cases)
- IoU < 0.7: 2.6% of cells
- IoU ≥ 0.9: 16.6% of cells (near-identical)

## Migration semantics

- Per-experiment migration: experiments that have only run the legacy step continue to work; experiments that have run the new step transparently pick up the better masks.
- No re-run of legacy experiments needed.
- Re-training of models that consume these masks is optional but recommended once a critical mass of experiments has been re-segmented (a model trained on legacy masks will see a small distribution shift inferring on new masks: ~1.8% mean feature shift, ~0.8% of cells with meaningfully different features).

## Cross-PR

Pairs with: royerlab/ops_process#113

🤖 Generated with [Claude Code](https://claude.com/claude-code)